### PR TITLE
Fix issue where in the month of january the random_month_number retur…

### DIFF
--- a/server/lib/generator.rb
+++ b/server/lib/generator.rb
@@ -110,7 +110,7 @@ class Dataset
 
   def resurrected_user_purchase_behavior(user)
     month_number        = Date.today.month
-    random_month_number = rand(2..month_number - 1)
+    random_month_number = (month_number == 1 ? rand(5..11) : rand(2..month_number - 1))
     random_past_month   = Date.today.prev_month(random_month_number)
     random_past_month_in_words = random_past_month.strftime('%B').downcase
 


### PR DESCRIPTION
There is a bug in the creation of the resurrected user segment where in January the `random_past_number` returns nil. Blocking the dataset from being sent to CSV or to Mixpanel.

This happens because a random month is selected on the basis of looking at a range between February and the past month. In January the month is 1, and by doing - 1 we trigger a nil statement.

This fix has been tested and makes the generator work again. 